### PR TITLE
Node's HTTP(S) and Streams for uploading files 

### DIFF
--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -292,7 +292,27 @@ Cloudfiles.prototype.addFile = function (container, file, local, options, callba
     headers: options.headers
   };
   
-  utils.rackspaceCurl(options, callback, function (body, res) {
+  utils.rackspaceRequest(options, callback, function (body, res) {
+    callback(null, true);
+  });
+};
+
+Cloudfiles.prototype.addFileFromStream = function (container, file, readStream, options, callback) {
+  if (typeof options === 'function' && !callback) {
+    callback = options;
+    options = {};
+  }
+
+  var options = {
+    method: 'PUT',
+    client: this,
+    uri: this.storageUrl(container, file),
+    readStream: readStream,
+    contentType: cloudfiles.mime.type(file),
+    headers: options.headers
+  };
+  
+  utils.rackspaceRequest(options, callback, function (body, res) {
     callback(null, true);
   });
 };

--- a/lib/cloudfiles/utils.js
+++ b/lib/cloudfiles/utils.js
@@ -181,7 +181,7 @@ var contentTypeOptions = '-H "Content-Type: {{content-type}}" ',
     fileOptions        = '-T {{filename}} ',
     outputOptions      = ' -o {{filename}}';
 
-utils.rackspaceCurl = function (options, callback, success) {
+utils.rackspaceRequest = function (options, callback, success) {
   var headers = options.headers || {};
   var readStream, client = options['client'];
   
@@ -208,6 +208,11 @@ utils.rackspaceCurl = function (options, callback, success) {
       makeRequest();
     });
   } else {
+    if (options.readStream) {
+      // use provided readStream -- assume Content-Length is already set
+      readStream = options.readStream;
+    }
+    
     // make the request
     makeRequest();
   }

--- a/lib/cloudfiles/utils.js
+++ b/lib/cloudfiles/utils.js
@@ -182,50 +182,73 @@ var contentTypeOptions = '-H "Content-Type: {{content-type}}" ',
     outputOptions      = ' -o {{filename}}';
 
 utils.rackspaceCurl = function (options, callback, success) {
-  var command = 'curl -i ', error = '', data = '', client = options['client'];
+  var headers = options.headers || {};
+  var readStream, client = options['client'];
+  
+  headers['X-Auth-Token'] = client.config.authToken;
+  
+  var urlParts = url.parse(options.uri);
+  
+  var httpClient = urlParts.protocol === 'https:' ? require('https') : require('http');
+  
   if (options.contentType) {
-    command += contentTypeOptions.replace('{{content-type}}', options.contentType);
+    headers['Content-Type'] = options.contentType;
   }
   
   if (options.filename) {
-    command += fileOptions.replace('{{filename}}', options.filename);
-  }
-
-  if (typeof options.headers === 'object') {
-    Object.keys(options.headers).forEach(function(name) {
-      command += headerOptions.replace('{{name}}', name)
-                              .replace('{{value}}', options.headers[name]);
+    // get file size
+    fs.stat(options.filename, function(err, stats) {
+      if (err)
+        return callback(err);
+        
+      headers['Content-Length'] = stats.size;
+      readStream = fs.createReadStream(options.filename);
+      
+      // send the file
+      makeRequest();
     });
+  } else {
+    // make the request
+    makeRequest();
   }
   
-  command += authTokenOptions.replace('{{auth-token}}', client.config.authToken);
-  command += curlOptions.replace('{{method}}', options.method).replace('{{uri}}', options.uri);
+  function makeRequest() {
+    var httpOptions = {
+      path: urlParts.pathname,
+      host: urlParts.host,
+      method: options.method,
+      headers: headers
+    };
 
-  var child = exec(command, function (error, stdout, stderr) {
-    if (error) return callback(error);
-    
-    try {
-      var statusCode = stdout.match(/HTTP\/1.1\s(\d+)/)[1];
-      if (Object.keys(failCodes).indexOf(statusCode.toString()) !== -1) {
-        return callback(new Error('Rackspace Error (' + statusCode + '): ' + failCodes[statusCode]));
+    var req = httpClient.request(httpOptions, function(res) {
+      if (Object.keys(failCodes).indexOf(res.statusCode.toString()) !== -1) {
+        return callback(new Error('Rackspace Error (' + res.statusCode + '): ' + failCodes[res.statusCode]));
       }
 
-      var successData = {
-        statusCode : statusCode
-      };
-    
+      res.setEncoding('utf8');
 
-      successData.bytes = stdout.match(/Content-Length: (\d+)/)[1];
-      successData.hash = stdout.match(/Etag: (\w+)/)[1];
-      successData.lastModified = stdout.match(/Last-Modified: (.*)$/m);
-      successData.contentType = stdout.match(/Content-Type: (.*)$/m);
+      res.on('end', function() {
+        var successData = {
+          statusCode: res.statusCode
+        };
 
-      success(null, successData);
+        successData.bytes = res.headers['content-length'];
+        successData.hash = res.headers['etag'];
+        successData.lastModified = res.headers['last-modified'];
+        successData.contentType = res.headers['content-type'];
+
+        success(null, successData);
+      });
+    })
+
+    if (readStream) {
+      readStream.pipe(req); 
     }
-    catch (ex) {
-      callback(ex); 
-    }
-  });
+
+    req.on('error', function(error) {
+      return callback(error);
+    });
+  }
 };
 
 utils.curlDownload = function (options, callback, success) {

--- a/lib/cloudfiles/utils.js
+++ b/lib/cloudfiles/utils.js
@@ -233,6 +233,8 @@ utils.rackspaceRequest = function (options, callback, success) {
       res.setEncoding('utf8');
 
       res.on('end', function() {
+        res.destroy(); // close the socket!
+
         var successData = {
           statusCode: res.statusCode
         };
@@ -247,12 +249,16 @@ utils.rackspaceRequest = function (options, callback, success) {
     })
 
     if (readStream) {
-      readStream.pipe(req); 
+      readStream.pipe(req);
+      req.end();
+    } else {
+      req.end();
     }
 
     req.on('error', function(error) {
       return callback(error);
     });
+
   }
 };
 

--- a/lib/cloudfiles/utils.js
+++ b/lib/cloudfiles/utils.js
@@ -202,15 +202,17 @@ utils.rackspaceRequest = function (options, callback, success) {
         return callback(err);
         
       headers['Content-Length'] = stats.size;
+
       readStream = fs.createReadStream(options.filename);
-      
-      // send the file
+      readStream.pause();
+  
       makeRequest();
     });
   } else {
     if (options.readStream) {
       // use provided readStream -- assume Content-Length is already set
       readStream = options.readStream;
+      readStream.pause();
     }
     
     // make the request
@@ -218,6 +220,9 @@ utils.rackspaceRequest = function (options, callback, success) {
   }
   
   function makeRequest() {
+    if (readStream)
+      headers['Expect'] = '100-continue';
+    
     var httpOptions = {
       path: urlParts.pathname,
       host: urlParts.host,
@@ -233,8 +238,6 @@ utils.rackspaceRequest = function (options, callback, success) {
       res.setEncoding('utf8');
 
       res.on('end', function() {
-        res.destroy(); // close the socket!
-
         var successData = {
           statusCode: res.statusCode
         };
@@ -246,12 +249,14 @@ utils.rackspaceRequest = function (options, callback, success) {
 
         success(null, successData);
       });
-    })
+    });
 
     if (readStream) {
-      readStream.pipe(req);
-      req.end();
-    } else {
+      req.on('continue', function() {
+        readStream.resume();
+        readStream.pipe(req);
+      });
+    } else { 
       req.end();
     }
 

--- a/test/storage-object-test.js
+++ b/test/storage-object-test.js
@@ -35,6 +35,17 @@ vows.describe('node-cloudfiles/storage-object').addBatch({
       "should respond with true": function (err, uploaded) {
         assert.isTrue(uploaded);
       }
+    },
+    "the addFile() method with a pre-provided read stream": {
+      topic: function () {
+        var fileName = path.join(__dirname, '..', 'test', 'fixtures', 'fillerama.txt');
+        var readStream = fs.createReadStream(fileName);
+        var options = { headers: {'Content-Length': fs.statSync(fileName).size }};
+        client.addFileFromStream('test_container', 'file3.txt', readStream, options, this.callback);
+      },
+      "should respond with true": function (err, uploaded) {
+        assert.isTrue(uploaded);
+      }
     }
   }
 }).addBatch({


### PR DESCRIPTION
Hi,

I rewrote the rackspaceCurl method using Node's HTTP(S) and Streams. This is so that I can provide a custom in-memory Stream.
- Use Node's HTTP(S) and Streams to upload files
- Renamed rackspaceCurl to rackspaceRequest
- Allow providing custom Stream
- Add test for custom stream

All tests pass.

BR,

Jak
