### PR TITLE
Allows transfer to Cloud Files over ServiceNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Each Container has a set of 'StorageObjects' (or files) which can be retrieved v
     //
     // Uploading a file
     //
-    client.addFile('myContainer', 'remoteName.txt', 'path/to/local/file.txt', function (err, uploaded) {
+    client.addFile('myContainer', { remote: 'remoteName.txt', local: 'path/to/local/file.txt' }, function (err, uploaded) {
       // File has been uploaded
     });
   

--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ Use the 'host' key in the auth configuration to specify the url to use for authe
   var client = cloudfiles.createClient(config);
 ``` 
 
+## Transfer over ServiceNet
+
+Rackspace Cloud Servers have a private interface, known as ServiceNet, that is unmetered and has double the throughput of the public interface.  When transferring files between a Cloud Server and Cloud Files, ServiceNet can be used instead of the public interface.
+
+By default, ServiceNet is not used.  To use ServiceNet for the transfer, set the 'servicenet' key to `true` in your client config:
+
+``` js 
+  var cloudfiles = require('cloudfiles');
+  var config = {
+    auth : {
+      username: 'your-username',
+      apiKey: 'your-api-key',
+      host : "lon.auth.api.rackspacecloud.com"
+    },
+    servicenet: true
+  };
+
+  var client = cloudfiles.createClient(config);
+``` 
+
+NOTE: ServiceNet can only be used to transfer files between Cloud Servers and Cloud Files within the same datacenter.  Rackspace support can migrate both Cloud Servers and Cloud Files to the same datacenter if needed.
+
 ## Roadmap
 
 1. Implement Storage Object metadata APIs.  

--- a/lib/cloudfiles/config.js
+++ b/lib/cloudfiles/config.js
@@ -41,6 +41,8 @@ var Config = exports.Config = function (options) {
   
   var cachePath = path.join(this.cache.path, this.auth.username);
   this.cache.path = options.cache ? options.cache.cachePath || cachePath : cachePath;
+
+  this.servicenet = options.servicenet === true;
 };
  
 Config.prototype = {
@@ -50,7 +52,22 @@ Config.prototype = {
   },
   cache: {
     path: path.join(__dirname, '..', '..', '.cache')
+  },
+  servicenet: false
+};
+
+//
+// ### function setStorageUrl (storageUrl)
+// ### @storageUrl {string} Rackspace Cloudfiles storage URL
+// Sets the storage URL for this instance, updating to the Serive Net URL if
+// Service Net transfer has been specified.
+Config.prototype.setStorageUrl = function(storageUrl) {
+  if (this.servicenet === true) {
+    this.storageUrl = storageUrl.replace('https://', 'https://snet-');
+  } else {
+    this.storageUrl = storageUrl;
   }
 };
+
 
 

--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -66,7 +66,7 @@ Cloudfiles.prototype.setAuth = function (callback) {
 
     self.authorized = true;
     self.config.serverUrl = res.headers['x-server-management-url'];
-    self.config.storageUrl = res.headers['x-storage-url'];
+    self.config.setStorageUrl(res.headers['x-storage-url']);
     self.config.cdnUrl = res.headers['x-cdn-management-url'];
     self.config.authToken = res.headers['x-auth-token'];
     self.config.storageToken = res.headers['x-storage-token']

--- a/test/servicenet-test.js
+++ b/test/servicenet-test.js
@@ -24,7 +24,7 @@ var client = helpers.createClient(),
     
 vows.describe('node-cloudfiles/servicenet').addBatch({
   "The node-cloudfiles client": {
-    "with valid credentials and not specifying Service Net transfer": {
+    "with valid credentials and not specifying ServiceNet transfer": {
       topic: function () {
         client.setAuth(this.callback);
       },
@@ -36,12 +36,12 @@ vows.describe('node-cloudfiles/servicenet').addBatch({
         assert.include(res.headers, 'x-cdn-management-url');
         assert.include(res.headers, 'x-auth-token');
       },
-      "should update the config with non-Service Net storage url": function (err, res) {
+      "should update the config with non-ServiceNet storage url": function (err, res) {
         assert.equal(res.headers['x-storage-url'], client.config.storageUrl);
         assert.ok(client.config.storageUrl.substring(0, 13) != 'https://snet-');
       }
     },
-    "with valid credentials and specifying Service Net transfer": {
+    "with valid credentials and specifying ServiceNet transfer": {
       topic: function () {
         snClient.setAuth(this.callback);
       },
@@ -53,7 +53,7 @@ vows.describe('node-cloudfiles/servicenet').addBatch({
         assert.include(res.headers, 'x-cdn-management-url');
         assert.include(res.headers, 'x-auth-token');
       },
-      "should update the config with non-Service Net storage url": function (err, res) {
+      "should update the config with non-ServiceNet storage url": function (err, res) {
         assert.notEqual(res.headers['x-storage-url'], snClient.config.storageUrl);
         assert.ok(snClient.config.storageUrl.substring(0, 13) == 'https://snet-');
       }

--- a/test/servicenet-test.js
+++ b/test/servicenet-test.js
@@ -1,0 +1,63 @@
+/*
+ * servicenet-test.js: Tests for Rackspace Cloudfiles Service Net transfer
+ *
+ * MIT LICENSE
+ *
+ */
+
+var path = require('path'),
+    vows = require('vows'),
+    assert = require('assert'),
+    helpers = require('./helpers'),
+    cloudfiles = require('../lib/cloudfiles');
+
+// Create a config that has servicenet = true
+var testConfig = helpers.loadConfig(),
+    snConfig = {};
+for (var key in testConfig) {
+  if (testConfig.hasOwnProperty(key)) snConfig[key] = testConfig[key];
+}
+snConfig.servicenet = true;
+
+var client = helpers.createClient(),
+    snClient = cloudfiles.createClient(snConfig);
+    
+vows.describe('node-cloudfiles/servicenet').addBatch({
+  "The node-cloudfiles client": {
+    "with valid credentials and not specifying Service Net transfer": {
+      topic: function () {
+        client.setAuth(this.callback);
+      },
+      "should respond with 204 and appropriate headers": function (err, res) {
+        assert.equal(res.statusCode, 204); 
+        assert.isObject(res.headers);
+        assert.include(res.headers, 'x-server-management-url');
+        assert.include(res.headers, 'x-storage-url');
+        assert.include(res.headers, 'x-cdn-management-url');
+        assert.include(res.headers, 'x-auth-token');
+      },
+      "should update the config with non-Service Net storage url": function (err, res) {
+        assert.equal(res.headers['x-storage-url'], client.config.storageUrl);
+        assert.ok(client.config.storageUrl.substring(0, 13) != 'https://snet-');
+      }
+    },
+    "with valid credentials and specifying Service Net transfer": {
+      topic: function () {
+        snClient.setAuth(this.callback);
+      },
+      "should respond with 204 and appropriate headers": function (err, res) {
+        assert.equal(res.statusCode, 204); 
+        assert.isObject(res.headers);
+        assert.include(res.headers, 'x-server-management-url');
+        assert.include(res.headers, 'x-storage-url');
+        assert.include(res.headers, 'x-cdn-management-url');
+        assert.include(res.headers, 'x-auth-token');
+      },
+      "should update the config with non-Service Net storage url": function (err, res) {
+        assert.notEqual(res.headers['x-storage-url'], snClient.config.storageUrl);
+        assert.ok(snClient.config.storageUrl.substring(0, 13) == 'https://snet-');
+      }
+    },
+  }
+}).export(module);
+


### PR DESCRIPTION
Rackspace allows transfer between Cloud Servers and Cloud Files using the private network adapter, Service Net, which is rad, because Service Net is unmetered and 2x the speed of the public interface.  I didn't see this noted in their API docs, but it's a feature in the Rackspace API clients.  All that's required to implement this is prepending 'snet-' to the storage URL (https://github.com/rackspace/python-cloudfiles/blob/master/cloudfiles/connection.py#L106-109).

I've made the appropriate changes to the configuration object and `createClient` as well as created a separate vows test.
