### PR TITLE
setAuth() should fail with error on non-204 response

### DIFF
--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -64,6 +64,12 @@ Cloudfiles.prototype.setAuth = function (callback) {
       return callback(err); 
     }
 
+    var statusCode = res.statusCode.toString();
+    if (Object.keys(common.failCodes).indexOf(statusCode) !== -1) {
+      err = new Error('Rackspace Error (' + statusCode + '): ' + common.failCodes[statusCode]);
+      return callback(err, res);
+    }
+
     self.authorized = true;
     self.config.serverUrl = res.headers['x-server-management-url'];
     self.config.setStorageUrl(res.headers['x-storage-url']);

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -46,7 +46,8 @@ vows.describe('node-cloudfiles/authentication').addBatch({
         
         invalidClient.setAuth(this.callback);
       },
-      "should respond with 401": function (err, res) {
+      "should respond with 401 and return an error": function (err, res) {
+        assert.ok(err instanceof Error);
         assert.equal(res.statusCode, 401);
       }
     },


### PR DESCRIPTION
For some reason, when the request initiated by `setAuth()` returns a non-204 response (ie. 401 due to invalid api key, etc), no error is being returned and `authorized` is being set to true, even though all the config items (serverUrl, setStorageUrl, cdnUrl, etc) are undefined because of the unauthorized response. This leads to unexpected behavior since you're assuming you have authorization.

[Relevant lines (lib/cloudfiles/core.js:62-75)](https://github.com/nodejitsu/node-cloudfiles/blob/master/lib/cloudfiles/core.js#L62-75):

``` js
request(authOptions, function (err, res, body) {
  if (err) {
    return callback(err); 
  }

  self.authorized = true;
  self.config.serverUrl = res.headers['x-server-management-url'];
  self.config.setStorageUrl(res.headers['x-storage-url']);
  self.config.cdnUrl = res.headers['x-cdn-management-url'];
  self.config.authToken = res.headers['x-auth-token'];
  self.config.storageToken = res.headers['x-storage-token']

  callback(null, res, self.config);
});
```

We should probably also be checking that the res.statusCode is equal to 200, as per the [documentation for request](https://github.com/mikeal/request):

``` js
var request = require('request');
request('http://www.google.com', function (error, response, body) {
  if (!error && response.statusCode == 200) {
    console.log(body) // Print the google web page.
  }
})
```
