### PR TITLE
destroyFile() isn't calling callback on failure

### DIFF
--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -385,7 +385,7 @@ Cloudfiles.prototype.addFile = function (container, options, callback) {
 // Destroys the `file` in the specified `container`.
 //
 Cloudfiles.prototype.destroyFile = function (container, file, callback) {
-  common.rackspace('DELETE', this.storageUrl(container, file), this, function (body, res) {
+  common.rackspace('DELETE', this.storageUrl(container, file), this, callback, function (body, res) {
     callback(null, true);
   });
 };

--- a/test/storage-object-test.js
+++ b/test/storage-object-test.js
@@ -129,6 +129,14 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
           assert.isTrue(deleted);
         }
       }
+    , "for a file that does not exist": {
+        topic: function () {
+          client.destroyFile('test_container', 'file0.txt', this.callback);
+        },
+        "should return error": function (err, deleted) {
+          assert.ok(err instanceof Error);
+        }
+      }
     }
   }
 }).addBatch({


### PR DESCRIPTION
For some reason `destroyFile()` wasn't calling my callback when it failed (ie. 404 Item not found), so digging into the code a bit I noticed that its [not passing an error callback to `common.rackspace()`](https://github.com/nodejitsu/node-cloudfiles/blob/master/lib/cloudfiles/core.js#L387-391).

Simple adding the callback before the last argument seems to work for me. If this is acceptable I'll be happy to open a pull request:

``` js

Cloudfiles.prototype.destroyFile = function (container, file, callback) {
  common.rackspace('DELETE', this.storageUrl(container, file), this, callback, function (body, res) {
    callback(null, true);
  });
};

```
