### PR TITLE
Update createContainer to return a correct container in callback

### DIFF
--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -194,8 +194,11 @@ Cloudfiles.prototype.createContainer = function (container, callback) {
         callback(null, new (cloudfiles.Container)(self, container));
       });
     }
+    else if (container instanceof cloudfiles.Container) {
+      callback(null, container);
+    }
     else {
-      callback(null, new (cloudfiles.Container)(self, container));
+      callback(null, new (cloudfiles.Container)(self, { name: containerName }));
     }
   });
 };


### PR DESCRIPTION
Update createContainer to return a correct container when container was a string in arguments and if container was already an instance of cloudfiles.Container.
