### PR TITLE
cloudfile: config: add proxy option

### DIFF
--- a/lib/cloudfiles/config.js
+++ b/lib/cloudfiles/config.js
@@ -7,6 +7,7 @@
  */
 
 var fs = require('fs'),
+    url = require('url'),
     path = require('path');
 
 var defaultAuthHost = 'auth.api.rackspacecloud.com';
@@ -43,6 +44,7 @@ var Config = exports.Config = function (options) {
   this.cache.path = options.cache ? options.cache.cachePath || cachePath : cachePath;
 
   this.servicenet = options.servicenet === true;
+  this.proxy = options.proxy || false;
 };
  
 Config.prototype = {
@@ -53,7 +55,8 @@ Config.prototype = {
   cache: {
     path: path.join(__dirname, '..', '..', '.cache')
   },
-  servicenet: false
+  servicenet: false,
+  proxy: false
 };
 
 //

--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -57,7 +57,11 @@ Cloudfiles.prototype.setAuth = function (callback) {
       'X-AUTH-KEY': this.config.auth.apiKey
     }
   };
-  
+
+  if (this.config.proxy !== false) {
+    authOptions.proxy = this.config.proxy;
+  }
+
   var self = this;
   request(authOptions, function (err, res, body) {
     if (err) {


### PR DESCRIPTION
I want to proxy all of my cloudfiles requests through an encrypting http
proxy, make this possible.

There might be a better way to do this that I am not thinking of.
