### PR TITLE
Added support for streaming file down from RackSpace.

### DIFF
--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -309,7 +309,16 @@ Cloudfiles.prototype.getFiles = function (container, download, callback) {
   });
 };
 
-Cloudfiles.prototype.getFile = function (container, filename, callback) {
+//
+// ### function getFile (container, filename, writableStream, callback)
+// #### @container {string} Name of the container to retrieve the file from
+// #### @filename {string} Name of the file to retrieve.
+// #### @writableStream {Stream} If set, use this writable stream to pipe
+//         the content of the file instead of using file stream.
+// #### @callback {function} Continuation to respond to when complete.
+// Retrieve the `file` in the specified `container`.
+//
+Cloudfiles.prototype.getFile = function (container, filename, writableStream, callback) {
   var self = this, 
       containerPath = path.join(this.config.cache.path, container),
       cacheFile = path.join(containerPath, filename),
@@ -317,7 +326,12 @@ Cloudfiles.prototype.getFile = function (container, filename, callback) {
   
   common.statOrMkdirp(containerPath);
   
-  var lstream = fs.createWriteStream(cacheFile),
+  if ("function" === typeof(writableStream)) {
+    callback = writableStream;
+    writableStream = null;
+  }
+  
+  var lstream = writableStream || fs.createWriteStream(cacheFile),
       rstream,
       options;
       


### PR DESCRIPTION
By default, `getFile` downloads the file from RackSpace into a temporary location.
This change supports piping the file to another stream that, in turn, can be piped
to some other module such as `gm` to resize the file without touching the disk.
