### PR TITLE
Encode uri to support utf8 chars

### DIFF
--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -414,9 +414,11 @@ Cloudfiles.prototype.destroyFile = function (container, file, callback) {
 //
 Cloudfiles.prototype.storageUrl = function () {
   var args = Array.prototype.slice.call(arguments),
-      json = (typeof(args[args.length - 1]) === 'boolean') && args.pop();
+      json = (typeof(args[args.length - 1]) === 'boolean') && args.pop(),
+      pathname;
   
-  return [this.config.storageUrl].concat(args).join('/') + (json ? '?format=json' : '');
+  pathname = '/' + encodeURI(args.join('/') + (json ? '?format=json' : ''));
+  return this.config.storageUrl + pathname;
 };
 
 //
@@ -427,7 +429,9 @@ Cloudfiles.prototype.storageUrl = function () {
 //
 Cloudfiles.prototype.cdnUrl = function () {
   var args = Array.prototype.slice.call(arguments),
-      json = (typeof(args[args.length - 1]) === 'boolean') && args.pop();
+      json = (typeof(args[args.length - 1]) === 'boolean') && args.pop(),
+      pathname;
   
-  return [this.config.cdnUrl].concat(args).join('/') + (json ? '?format=json' : '');
+  pathname = '/' + encodeURI(args.join('/') + (json ? '?format=json' : ''));
+  return this.config.cdnUrl + pathname;
 };

--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -343,6 +343,27 @@ Cloudfiles.prototype.getFile = function (container, filename, callback) {
   });
 };
 
+Cloudfiles.prototype.streamFile = function(container, filename, lstream, callback) {
+  var self = this, 
+      containerPath = path.join(this.config.cache.path, container),
+      cacheFile = path.join(containerPath, filename),
+      options;
+  common.statOrMkdirp(containerPath);
+  
+  var rstream,
+      options;
+      
+  options = {
+    method: 'GET', 
+    client: self,
+    uri: self.storageUrl(container, filename),
+    download: lstream
+  };
+
+  rstream = common.rackspace(options, callback);
+};
+
+
 //
 // options
 //   remote


### PR DESCRIPTION
A filename, which is part of request URI in many APIs, is not necessary to be consisted of only English chars. 

Considering support for such non-asci chars, we should encodeURI() before sending the request.

In fact, current implementation of storageUrl and cdnUrl really annoys me when uploading files with Chinese file names as the server responds no error but files are nowhere to be seen on the Cloudfile.

And the problem goes away with this fix.
