### PR TITLE
Add reconnect support as cloudfiles invalidates tokens every 24 hours.

### DIFF
--- a/lib/cloudfiles/common.js
+++ b/lib/cloudfiles/common.js
@@ -1,5 +1,6 @@
 /*
- * core.js: Core functions for accessing Rackspace CloudFiles
+ * common.js: Shared functions for accessing Rackspace CloudFiles
+ * Used by functions in core.js
  *
  * (C) 2010 Nodejitsu Inc.
  * MIT LICENSE
@@ -43,7 +44,7 @@ var successCodes = common.successCodes = {
   204: "No content",
 };
 
-// 
+//
 // ### function statOrMkDirp (path)
 // #### @path {string} Path to validate or create.
 // Checks if a directory exists. If not, creates that directory
@@ -51,7 +52,7 @@ var successCodes = common.successCodes = {
 common.statOrMkdirp = function (path) {
   try { fs.statSync(path) }
   catch (ex) { mkdirpSync(path, 0755) }
-  
+
   return path;
 };
 
@@ -86,14 +87,14 @@ common.mixin = function (target) {
   return target;
 };
 
- 
+
 //
 // Core method that actually sends requests to Rackspace.
-// This method is designed to be flexible w.r.t. arguments 
+// This method is designed to be flexible w.r.t. arguments
 // and continuation passing given the wide range of different
 // requests required to fully implement the CloudFiles API.
-// 
-// Continuations: 
+//
+// Continuations:
 //   1. 'callback': The callback passed into every node-cloudfiles method
 //   2. 'success':  A callback that will only be called on successful requests.
 //                  This is used throughout node-cloudfiles to conditionally
@@ -114,18 +115,18 @@ common.rackspace = function () {
       download,
       upload,
       rstream;
-      
+
   //
   // Now that we've popped off the two callbacks
   // We can make decisions about other arguments
   //
-  if (args.length == 1) {  
+  if (args.length == 1) {
     client          = args[0]['client'];
     options.headers = args[0]['headers'] || {};
     options.method  = args[0]['method']  || 'GET';
     options.body    = args[0]['body'];
     options.uri     = args[0]['uri'];
-    
+
     //
     // Attempt to grab the `upload` or `download` streams
     // (if they exist).
@@ -135,7 +136,7 @@ common.rackspace = function () {
   }
   else if (args.length === 2) {
     //
-    // If we got a string assume that it's the URI 
+    // If we got a string assume that it's the URI
     //
     client         = args[1];
     options.method = 'GET';
@@ -146,11 +147,11 @@ common.rackspace = function () {
     options.method = args[0];
     options.uri    = args[1];
   }
-  
+
   if (!client.authorized) {
     return callback(new Error('Cannot make Rackspace request if not authorized'));
   }
-  
+
   //
   // Append the `x-auth-token` header for Rackspace authentication
   //
@@ -162,42 +163,58 @@ common.rackspace = function () {
   if (typeof options.body !== 'undefined' && !options.headers['content-type']) {
     options.headers['content-type'] = 'application/json';
     options.body = JSON.stringify(options.body);
-  } 
-  
+  }
+
   if (upload) {
     if (!options.headers['content-length']) {
       options.headers['transfer-encoding'] = 'chunked';
     }
   }
-  
+
   rstream = request(options, function (err, res, body) {
     if (err) {
       if (callback) {
         callback(err);
       }
-      
+
       return;
     }
 
     var statusCode = res.statusCode.toString();
     if (Object.keys(failCodes).indexOf(statusCode) !== -1) {
-      if (callback) {
+      if(callback && statusCode === "401"){
+        // Looks like we lost our auth token. Rackspace invalidates every 24 hours so that's probably why.
+        // Attempt to get another one then retry this action.
+        client.setAuth(function(err,res,config){
+          if(err) return callback(err);
+          // We need to recreate the streams as they have been closed by the last action.
+          if(args[0].upload){
+            args[0].upload = fs.createReadStream(args[0].upload.path);
+          }
+          if(args[0].download){
+            args[0].download = fs.createWriteStream(args[0].download.path);
+          }
+          // Redo the action.
+          common.rackspace(args[0], callback, success);
+        });
+      }
+      else if (callback) {
         callback(new Error('Rackspace Error (' + statusCode + '): ' + failCodes[statusCode]));
       }
-      
+
       return;
     }
 
     success(body, res);
   });
-  
+
   if (upload) {
     upload.pipe(rstream);
   }
   else if (download) {
     rstream.pipe(download);
   }
-  
+
   return rstream;
 };
 
@@ -209,32 +226,32 @@ common.runBatch = function (fns, finish) {
       errors = new Array(total),
       was_error = false,
       results = new Array(total);
-      
+
   fns.forEach(function (fn, i) {
     var once = false;
-    
+
     function next(err, value) {
       // Can be called only one time
       if (once) {
-        return;      
+        return;
       }
-      
+
       once = true;
-      
+
       // If have error - push them into errors
       if (err) {
         was_error = true;
         errors[i] = err;
-      } 
+      }
       else {
         results[i] = value;
       }
-            
+
       if (++finished === total) {
         finish(was_error ? errors : null, results);
       }
     }
-    
+
     var value = fn(next);
 
     // If function returns value - it won't be working in async mode
@@ -242,7 +259,7 @@ common.runBatch = function (fns, finish) {
       next(null, value);
     }
   });
-  
+
   if (fns.length === 0) {
     finish(null, []);
   }

--- a/lib/cloudfiles/core.js
+++ b/lib/cloudfiles/core.js
@@ -35,33 +35,33 @@ exports.createClient = function (options) {
 var Cloudfiles = exports.Cloudfiles = function (config) {
   this.config = config;
   this.authorized = false;
-  
+
   //
   // Create the cache path for this instance immediately.
   //
-  common.statOrMkdirp(this.config.cache.path)
+  common.statOrMkdirp(this.config.cache.path);
 };
 
 //
 // ### function setAuth (callback)
 // #### @callback {function} Continuation to respond to when complete.
-// Authenticates node-cloudfiles with the options specified 
+// Authenticates node-cloudfiles with the options specified
 // in the Config object for this instance
 //
 Cloudfiles.prototype.setAuth = function (callback) {
   var authOptions = {
-    uri: 'https://' + this.config.auth.host + '/v1.0', 
+    uri: 'https://' + this.config.auth.host + '/v1.0',
     headers: {
       'HOST': this.config.auth.host,
       'X-AUTH-USER': this.config.auth.username,
       'X-AUTH-KEY': this.config.auth.apiKey
     }
   };
-  
+
   var self = this;
   request(authOptions, function (err, res, body) {
     if (err) {
-      return callback(err); 
+      return callback(err);
     }
 
     var statusCode = res.statusCode.toString();
@@ -78,7 +78,7 @@ Cloudfiles.prototype.setAuth = function (callback) {
     self.config.storageToken = res.headers['x-storage-token']
 
     callback(null, res, self.config);
-  });  
+  });
 };
 
 //
@@ -95,7 +95,7 @@ Cloudfiles.prototype.getContainers = function () {
       url = isCdn ? this.cdnUrl(true) : this.storageUrl(true);
 
   common.rackspace(url, this, callback, function (body) {
-    var results = [], 
+    var results = [],
         containers = JSON.parse(body);
 
     containers.forEach(function (container) {
@@ -132,21 +132,21 @@ Cloudfiles.prototype.getContainer = function () {
       isCdn = args.length > 0 && (typeof(args[args.length - 1]) === 'boolean') && args.pop(),
       containerName = args.pop(),
       containerOptions;
-  
+
   containerOptions = {
     method: 'HEAD',
     uri: isCdn ? this.cdnUrl(containerName) : this.storageUrl(containerName),
     cdn: isCdn,
     client: this
   }
-  
+
   common.rackspace(containerOptions, callback, function (body, res) {
     var container = {
       name: containerName,
       count: new Number(res.headers['x-container-object-count']),
       bytes: new Number(res.headers['x-container-bytes-used'])
     };
-    
+
     if (isCdn) {
       container.cdnUri = res.headers['x-cdn-uri'];
       container.cdnSslUri = res.headers['x-cdn-ssl-uri'];
@@ -157,7 +157,7 @@ Cloudfiles.prototype.getContainer = function () {
       delete container.count;
       delete container.bytes;
     }
-    
+
     callback(null, new (cloudfiles.Container)(self, container));
   });
 };
@@ -172,12 +172,12 @@ Cloudfiles.prototype.getContainer = function () {
 Cloudfiles.prototype.createContainer = function (container, callback) {
   var self = this, 
       containerName = container instanceof cloudfiles.Container ? container.name : container;
-      
+
   common.rackspace('PUT', this.storageUrl(containerName), this, callback, function (body, res) {
     if (typeof container.cdnEnabled !== 'undefined' && container.cdnEnabled) {
       container.ttl = container.ttl || self.config.cdn.ttl;
       container.logRetention = container.logRetention || self.config.cdn.logRetention;
-      
+
       var cdnOptions = {
         uri: self.cdnUrl(containerName),
         method: 'PUT',
@@ -187,7 +187,7 @@ Cloudfiles.prototype.createContainer = function (container, callback) {
           'X-LOG-RETENTION': container.logRetention
         }
       };
-      
+
       common.rackspace(cdnOptions, callback, function (body, res) {
         container.cdnUri = res.headers['x-cdn-uri'];
         container.cdnSslUri = res.headers['x-cdn-ssl-uri'];
@@ -212,32 +212,32 @@ Cloudfiles.prototype.destroyContainer = function (container, callback) {
     if (err) {
       return callback(err);
     }
-    
+
     function deleteContainer (err) {
       if (err) {
         return callback(err);
       }
-      
+
       common.rackspace('DELETE', self.storageUrl(container), self, callback, function (body, res) {
         callback(null, true);
       });
     }
-    
+
     function destroyFile (file, next) {
       file.destroy(next);
     }
-    
+
     if (files.length === 0) {
       return deleteContainer();
     }
-    
+
     async.forEach(files, destroyFile, deleteContainer);
   });
 };
 
 Cloudfiles.prototype.getFiles = function (container, download, callback) {
   var self = this;
-  
+
   //
   // Download is optional argument
   // And can be only: true, false, [array of files]
@@ -252,20 +252,20 @@ Cloudfiles.prototype.getFiles = function (container, download, callback) {
 
   common.rackspace(this.storageUrl(container, true), this, callback, function (body) {
     var files = JSON.parse(body);
-    
+
     // If download == false or wasn't defined
     if (!download) {
       var results = files.map(function (file) {
         file.container = container;
         return new (cloudfiles.StorageObject)(self, file);
       });
-      
+
       callback(null, results);
       return;
     }
-    
+
     var batch;
-    
+
     if (download instanceof RegExp || download == true) {
       // If download == true
       // Download all files
@@ -274,21 +274,21 @@ Cloudfiles.prototype.getFiles = function (container, download, callback) {
           return download.test(file.name);
         });
       }
-      
+
       // Create a batch
       batch = files.map(function (file) {
         return function (callback) {
           self.getFile(container, file.name, callback);
         }
-      });      
-    } 
+      });
+    }
     else if (Array.isArray(download)) {
-      // Go through all files that we've asked to download 
+      // Go through all files that we've asked to download
       batch = download.map(function (file) {
         var exists = files.some(function (item) {
           return item.name == file
         });
-        
+
         // If file exists - get it
         // If not report about error
         return exists ?
@@ -299,30 +299,30 @@ Cloudfiles.prototype.getFiles = function (container, download, callback) {
               callback(Error('File : ' + file + ' doesn\'t exists'));
             };
       });
-    } 
+    }
     else {
       callback(Error('"download" argument can be only boolean, array or regexp'));
     }
-    
+
     // Run batch
     common.runBatch(batch, callback);
   });
 };
 
 Cloudfiles.prototype.getFile = function (container, filename, callback) {
-  var self = this, 
+  var self = this,
       containerPath = path.join(this.config.cache.path, container),
       cacheFile = path.join(containerPath, filename),
       options;
-  
+
   common.statOrMkdirp(containerPath);
-  
+
   var lstream = fs.createWriteStream(cacheFile),
       rstream,
       options;
-      
+
   options = {
-    method: 'GET', 
+    method: 'GET',
     client: self,
     uri: self.storageUrl(container, filename),
     download: lstream
@@ -371,11 +371,11 @@ Cloudfiles.prototype.addFile = function (container, options, callback) {
   else if (options.stream) {
     lstream = options.stream;
   }
-  
+
   if (!lstream) {
     return callback(new Error('.local or .stream is required to addFile.'));
   }
-  
+
   addOptions = {
     method: 'PUT',
     client: this,
@@ -383,11 +383,11 @@ Cloudfiles.prototype.addFile = function (container, options, callback) {
     uri: this.storageUrl(container, options.remote),
     headers: options.headers || {}
   };
-  
+
   if (options.headers && !options.headers['content-type']) {
     options.headers['content-type'] = mime.lookup(options.remote);
   }
-  
+
   return common.rackspace(addOptions, callback, function (body, res) {
     callback(null, true);
   });
@@ -410,12 +410,12 @@ Cloudfiles.prototype.destroyFile = function (container, file, callback) {
 // ### function storageUrl (arguments)
 // #### @arguments {Array} Lists of arguments to convert into a storage url.
 // Helper method that concats the string params into a url to request against
-// the authenticated node-cloudfiles storageUrl. 
+// the authenticated node-cloudfiles storageUrl.
 //
 Cloudfiles.prototype.storageUrl = function () {
   var args = Array.prototype.slice.call(arguments),
       json = (typeof(args[args.length - 1]) === 'boolean') && args.pop();
-  
+
   return [this.config.storageUrl].concat(args).join('/') + (json ? '?format=json' : '');
 };
 
@@ -423,11 +423,11 @@ Cloudfiles.prototype.storageUrl = function () {
 // ### function cdnUrl (arguments)
 // #### @arguments {Array} Lists of arguments to convert into a cdn url.
 // Helper method that concats the string params into a url
-// to request against the authenticated node-cloudfiles cdnUrl. 
+// to request against the authenticated node-cloudfiles cdnUrl.
 //
 Cloudfiles.prototype.cdnUrl = function () {
   var args = Array.prototype.slice.call(arguments),
       json = (typeof(args[args.length - 1]) === 'boolean') && args.pop();
-  
+
   return [this.config.cdnUrl].concat(args).join('/') + (json ? '?format=json' : '');
 };

--- a/test/authentication-test.js
+++ b/test/authentication-test.js
@@ -11,8 +11,8 @@ var path = require('path'),
     assert = require('assert'),
     helpers = require('./helpers'),
     cloudfiles = require('../lib/cloudfiles');
-    
-    
+
+
 var client = helpers.createClient();
 
 vows.describe('node-cloudfiles/authentication').addBatch({
@@ -23,7 +23,7 @@ vows.describe('node-cloudfiles/authentication').addBatch({
       },
       "should respond with 204 and appropriate headers": function (err, res) {
         assert.isNull(err);
-        assert.equal(res.statusCode, 204); 
+        assert.equal(res.statusCode, 204);
         assert.isObject(res.headers);
         assert.include(res.headers, 'x-server-management-url');
         assert.include(res.headers, 'x-storage-url');
@@ -40,13 +40,13 @@ vows.describe('node-cloudfiles/authentication').addBatch({
     },
     "with an invalid username and api key": {
       topic: function () {
-        var invalidClient = cloudfiles.createClient({ 
+        var invalidClient = cloudfiles.createClient({
           auth: {
-            username: 'invalid-username', 
+            username: 'invalid-username',
             apiKey: 'invalid-apikey'
           }
         });
-        
+
         invalidClient.setAuth(this.callback);
       },
       "should respond with 401 and return an error": function (err, res) {
@@ -55,4 +55,5 @@ vows.describe('node-cloudfiles/authentication').addBatch({
       }
     },
   }
+
 }).export(module);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,8 +14,8 @@ var util = require('util'),
     cloudfiles = require('../lib/cloudfiles');
 
 var helpers = exports,
-    testConfig, 
-    client; 
+    testConfig,
+    client;
 
 helpers.loadConfig = function () {
   try {
@@ -31,23 +31,24 @@ helpers.loadConfig = function () {
 
     testConfig = config;
     return config;
-    
+
   }
   catch (ex) {
+    console.log(ex);
     util.puts('Config file test/fixtures/test-config.json must be created with valid data before running tests.');
     process.exit(0);
-  }  
+  }
 };
 
 helpers.createClient = function () {
   if (!testConfig) {
     helpers.loadConfig();
   }
-  
+
   if (!client) {
     client = cloudfiles.createClient(testConfig);
   }
-  
+
   return client;
 };
 
@@ -59,7 +60,7 @@ helpers.assertContainer = function (container) {
 };
 
 helpers.assertCdnContainer = function (container) {
-  helpers.assertContainer(container); 
+  helpers.assertContainer(container);
   assert.isTrue(typeof container.ttl === 'number');
   assert.isTrue(typeof container.logRetention === 'boolean');
   assert.isTrue(typeof container.cdnUri === 'string');
@@ -104,7 +105,7 @@ helpers.requireAuth = function () {
         if (client.authorized) {
           return this.callback();
         }
-        
+
         client.setAuth(this.callback);
       },
       "the client is now authorized": function () {

--- a/test/storage-object-test.js
+++ b/test/storage-object-test.js
@@ -13,7 +13,7 @@ var path = require('path'),
     cloudfiles = require('../lib/cloudfiles'),
     helpers = require('./helpers');
 
-var testData = {}, client = helpers.createClient(), 
+var testData = {}, client = helpers.createClient(),
     sampleData = fs.readFileSync(path.join(__dirname, '..', 'test', 'fixtures', 'fillerama.txt')).toString();
 
 vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(client)).addBatch({
@@ -24,7 +24,7 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
           remote: 'file1.txt',
           local: path.join(__dirname, '..', 'test', 'fixtures', 'fillerama.txt')
         }, function () { });
-        
+
         ustream.on('end', this.callback);
       },
       "should raise the `end` event": function () {
@@ -40,8 +40,8 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
           remote: 'file2.txt',
           local: path.join(__dirname, '..', 'test', 'fixtures', 'fillerama.txt')
         }, function () { });
-        
-        ustream.on('end', this.callback)
+
+        ustream.on('end', this.callback);
       },
       "should raise the `end` event": function () {
         assert.isTrue(true);
@@ -56,13 +56,13 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
             readStream = fs.createReadStream(fileName),
             headers = { 'content-length': fs.statSync(fileName).size },
             ustream;
-            
+
         ustream = client.addFile('test_container', {
           remote: 'file3.txt',
           stream: readStream,
           headers: headers
         }, this.callback);
-        
+
         ustream.on('end', this.callback);
       },
       "should raise the `end` event": function () {
@@ -74,12 +74,12 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
         var fileName = path.join(__dirname, '..', 'test', 'fixtures', 'fillerama.txt'),
             readStream = fs.createReadStream(fileName),
             ustream;
-            
+
         ustream = client.addFile('test_container', {
           remote: 'file3.txt',
           stream: readStream
         }, this.callback);
-        
+
         ustream.on('end', this.callback);
       },
       "should raise the `end` event": function () {
@@ -124,7 +124,7 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
             if (err) {
               return self.callback(err);
             }
-            
+
             fs.stat(filename, self.callback)
           });
         },
@@ -167,6 +167,23 @@ vows.describe('node-cloudfiles/storage-object').addBatch(helpers.requireAuth(cli
           "should return true": function (err, deleted) {
             assert.isTrue(deleted);
           }
+        }
+      }
+    }
+  }
+}).addBatch({
+  "The node-cloudfiles client": {
+    "The addFile() method" : {
+      "Correctly reconnects after an accessToken is invalidated" : {
+        topic: function () {
+          client.config.authToken = "fakeToken";
+          var ustream = client.addFile('test_container', {
+            remote: 'file1.txt',
+            local: path.join(__dirname, '..', 'test', 'fixtures', 'fillerama.txt')
+          }, this.callback );
+        },
+        "should not return error": function (err, success) {
+          assert.isTrue(success);
         }
       }
     }


### PR DESCRIPTION
I have been running node-cloudfiles in production for a while to run an image uploader and have noticed that every once in a while the uploader stops working.

As it turns out, Cloudfiles invalidates your accessToken every 24 hours.

This pull request contains the necessary code to detect a 401, attempt a reAuth, and restart the previous failed request.
