### PR TITLE
fixes to addFile and Container construction

### DIFF
--- a/lib/cloudfiles/container.js
+++ b/lib/cloudfiles/container.js
@@ -12,6 +12,9 @@ var Container = exports.Container = function (client, details) {
   if (!details) {
     throw new Error("Container must be constructed with at least basic details.")
   }
+  if(typeof details !== 'object') {
+    details = {name: details};
+  }
 
   this.files = [];
   this.client = client;

--- a/lib/cloudfiles/container.js
+++ b/lib/cloudfiles/container.js
@@ -23,7 +23,16 @@ var Container = exports.Container = function (client, details) {
 
 Container.prototype = {
   addFile: function (file, local, options, callback) {
-    return this.client.addFile(this.name, file, local, options, callback);
+    if(!options && !callback) {
+      options = {};
+    }
+    if (typeof options === 'function' && !callback) {
+      callback = options;
+      options = {};
+    }
+    options.remote = file;
+    options.local = local;
+    return this.client.addFile(this.name, options, callback);
   },
   
   destroy: function (callback) {


### PR DESCRIPTION
Just a couple of things I ran into when trying to use this module.  The Container.addFile method didn't handle its arguments right when it passed the call onto the client.addFile method.  I also found it inconvenient to construct a container with an object all the time when all it really is is a string.
